### PR TITLE
fix #5: added proxy support

### DIFF
--- a/com.ifedorenko.p2browser.jnlp/pom.xml
+++ b/com.ifedorenko.p2browser.jnlp/pom.xml
@@ -25,7 +25,7 @@
   <packaging>eclipse-application</packaging>
 
   <properties>
-    <jnlp.codebase>file://${project.build.directory}/product/eclipse</jnlp.codebase>
+    <jnlp.codebase>file:///${project.build.directory}/product/eclipse</jnlp.codebase>
     <jnlp.deleteUnpackedJars>false</jnlp.deleteUnpackedJars>
   </properties>
 

--- a/com.ifedorenko.p2browser/META-INF/MANIFEST.MF
+++ b/com.ifedorenko.p2browser/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.equinox.p2.transport.ecf;bundle-version="1.0.0",
  org.eclipse.equinox.p2.director;bundle-version="2.1.0",
  org.eclipse.equinox.p2.engine;bundle-version="2.1.0",
- org.eclipse.equinox.p2.updatesite;bundle-version="1.0.300"
+ org.eclipse.equinox.p2.updatesite;bundle-version="1.0.300",
+ org.eclipse.core.net;bundle-version="1.2.200"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: com.ifedorenko.p2browser;x-internal:=true,

--- a/com.ifedorenko.p2browser/src/com/ifedorenko/p2browser/Application.java
+++ b/com.ifedorenko.p2browser/src/com/ifedorenko/p2browser/Application.java
@@ -11,46 +11,234 @@
 
 package com.ifedorenko.p2browser;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.net.proxy.IProxyData;
+import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 
 /**
  * This class controls all aspects of the application's execution
  */
 public class Application implements IApplication {
+    private static final ILog LOGGER = Activator.getDefault().getLog();
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.equinox.app.IApplication#start(org.eclipse.equinox.app.IApplicationContext)
-	 */
-	public Object start(IApplicationContext context) {
-		Display display = PlatformUI.createDisplay();
-		try {
-			int returnCode = PlatformUI.createAndRunWorkbench(display, new ApplicationWorkbenchAdvisor());
-			if (returnCode == PlatformUI.RETURN_RESTART) {
-				return IApplication.EXIT_RESTART;
-			}
-			return IApplication.EXIT_OK;
-		} finally {
-			display.dispose();
-		}
-	}
+    private static final String WS_PROX_TYPE_NONE = "0";
+    private static final String WS_PROX_TYPE_MANUAL = "1";
+    private static final String WS_PROX_TYPE_AUTO = "2";
+    private static final String WS_PROX_TYPE_BROWSER = "3";
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.equinox.app.IApplication#stop()
-	 */
-	public void stop() {
-		if (!PlatformUI.isWorkbenchRunning())
-			return;
-		final IWorkbench workbench = PlatformUI.getWorkbench();
-		final Display display = workbench.getDisplay();
-		display.syncExec(new Runnable() {
-			public void run() {
-				if (!display.isDisposed())
-					workbench.close();
-			}
-		});
-	}
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.equinox.app.IApplication#start(org.eclipse.equinox.app.IApplicationContext)
+     */
+    @Override
+    public Object start(final IApplicationContext context) {
+        final Display display = PlatformUI.createDisplay();
+        try {
+            logSystemProperties();
+            configureProxy();
+            logProxySettings();
+
+            final int returnCode = PlatformUI.createAndRunWorkbench(display, new ApplicationWorkbenchAdvisor());
+            if (returnCode == PlatformUI.RETURN_RESTART) {
+                return IApplication.EXIT_RESTART;
+            }
+            return IApplication.EXIT_OK;
+        } catch (final CoreException e) {
+            final IStatus status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Initialization failed", e);
+            LOGGER.log(status);
+            return IApplication.EXIT_OK;
+        } finally {
+            display.dispose();
+        }
+    }
+
+    private static void configureProxy() throws CoreException {
+        // get a copy of system props because IProxyService overwrites standard Java proxy properties
+        final Map<Object, Object> systemProperties = new HashMap<Object, Object>(System.getProperties());
+
+        final BundleContext bc = Activator.getDefault().getBundle().getBundleContext();
+        final ServiceReference<?> serviceReference = bc.getServiceReference(IProxyService.class.getName());
+        try {
+            final IProxyService proxyService = (IProxyService) bc.getService(serviceReference);
+
+            if (System.getProperty("deployment.proxy.type") != null) {
+                configureProxyViaWebStart(proxyService);
+            } else {
+                configureProxyViaStandardSystemProperties(systemProperties, proxyService);
+            }
+        } finally {
+            bc.ungetService(serviceReference);
+        }
+    }
+
+    private static void configureProxyViaWebStart(final IProxyService proxyService) throws CoreException {
+        final String proxyType = System.getProperty("deployment.proxy.type");
+        if (WS_PROX_TYPE_NONE.equals(proxyType)) {
+            proxyService.setProxiesEnabled(false);
+        } else if (WS_PROX_TYPE_MANUAL.equals(proxyType)) {
+            final boolean proxySame = Boolean.getBoolean(System.getProperty("deployment.proxy.same"));
+            final String httpProxyHost = System.getProperty("deployment.proxy.http.host");
+            final String httpProxyPort = System.getProperty("deployment.proxy.http.port");
+            final String httpsProxyHost = proxySame ? httpProxyHost : System.getProperty("deployment.proxy.https.host");
+            final String httpsProxyPort = proxySame ? httpProxyPort : System.getProperty("deployment.proxy.https.port");
+            final String nonProxyHosts = System.getProperty("deployment.proxy.bypass.list");
+
+            if (httpProxyHost != null) {
+                setProxyData(proxyService, IProxyData.HTTP_PROXY_TYPE, httpProxyHost, httpProxyPort);
+            }
+            if (httpsProxyHost != null) {
+                setProxyData(proxyService, IProxyData.HTTPS_PROXY_TYPE, httpsProxyHost, httpsProxyPort);
+            }
+
+            if (nonProxyHosts != null) {
+                proxyService.setNonProxiedHosts(nonProxyHosts.trim().split(","));
+            }
+
+            proxyService.setSystemProxiesEnabled(false);
+            proxyService.setProxiesEnabled(true);
+        } else if (WS_PROX_TYPE_AUTO.equals(proxyType)) {
+            final IStatus status =
+                new Status(IStatus.WARNING, Activator.PLUGIN_ID,
+                        "Java WebStart proxy type AUTO is not supported, falling back to system proxyies.");
+            LOGGER.log(status);
+            proxyService.setSystemProxiesEnabled(true);
+            proxyService.setProxiesEnabled(true);
+        } else if (WS_PROX_TYPE_BROWSER.equals(proxyType)) {
+            proxyService.setSystemProxiesEnabled(true);
+            proxyService.setProxiesEnabled(true);
+        } else {
+            final IStatus status =
+                new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+                        "Java WebStart proxy type unknown, deployment.proxy.type=" + proxyType);
+            LOGGER.log(status);
+        }
+    }
+
+    private static void configureProxyViaStandardSystemProperties(final Map<Object, Object> systemProperties,
+            final IProxyService proxyService) throws CoreException {
+        final String httpProxyHost = (String) systemProperties.get("http.proxyHost");
+        final String httpProxyPort = (String) systemProperties.get("http.proxyPort");
+        final String httpsProxyHost = (String) systemProperties.get("https.proxyHost");
+        final String httpsProxyPort = (String) systemProperties.get("https.proxyPort");
+        final String nonProxyHosts = (String) systemProperties.get("http.nonProxyHosts");
+
+        if (httpProxyHost != null) {
+            setProxyData(proxyService, IProxyData.HTTP_PROXY_TYPE, httpProxyHost, httpProxyPort);
+        }
+        if (httpsProxyHost != null) {
+            setProxyData(proxyService, IProxyData.HTTPS_PROXY_TYPE, httpsProxyHost, httpsProxyPort);
+        }
+
+        if (nonProxyHosts != null) {
+            proxyService.setNonProxiedHosts(nonProxyHosts.trim().split("\\|"));
+        }
+        proxyService.setSystemProxiesEnabled(false);
+        proxyService.setProxiesEnabled(true);
+    }
+
+    private static void setProxyData(final IProxyService proxyService, final String proxyType, final String proxyHost,
+            final String proxPort) throws CoreException {
+        final IProxyData proxyData = proxyService.getProxyData(proxyType);
+        proxyData.setHost(proxyHost);
+
+        int port = -1;
+        try {
+            port = Integer.parseInt(proxPort);
+        } catch (final NumberFormatException e) {
+            // ignore and use default (port 8080)
+        }
+        if (port < 0 || port > 65535) {
+            port = 8080;
+        }
+        proxyData.setPort(port);
+
+        proxyService.setProxyData(new IProxyData[] { proxyData });
+    }
+
+    private static void logProxySettings() {
+        final BundleContext bc = Activator.getDefault().getBundle().getBundleContext();
+
+        final ServiceReference<?> serviceReference = bc.getServiceReference(IProxyService.class.getName());
+        try {
+            final IProxyService proxyService = (IProxyService) bc.getService(serviceReference);
+
+            IStatus status =
+                new Status(IStatus.INFO, Activator.PLUGIN_ID, "proxiesEnabled=" + proxyService.isProxiesEnabled());
+            LOGGER.log(status);
+
+            final boolean hasSystemProxies = proxyService.hasSystemProxies();
+            final boolean systemProxiesEnabled = proxyService.isSystemProxiesEnabled();
+            status =
+                new Status((!hasSystemProxies && systemProxiesEnabled) ? IStatus.ERROR : IStatus.INFO,
+                        Activator.PLUGIN_ID, "hasSystemProxies=" + hasSystemProxies + ", systemProxiesEnabled="
+                                + systemProxiesEnabled);
+            LOGGER.log(status);
+
+            for (final IProxyData proxyData : proxyService.getProxyData()) {
+                final String message =
+                    "Type=" + proxyData.getType() + ", host=" + proxyData.getHost() + ", port=" + proxyData.getPort();
+                status = new Status(IStatus.INFO, Activator.PLUGIN_ID, message);
+                LOGGER.log(status);
+            }
+            status =
+                new Status(IStatus.INFO, Activator.PLUGIN_ID, "nonProxiedHosts="
+                        + Arrays.toString(proxyService.getNonProxiedHosts()));
+            LOGGER.log(status);
+
+        } finally {
+            bc.ungetService(serviceReference);
+        }
+    }
+
+    // just for debugging
+    private static void logSystemProperties() {
+        final StringBuffer msg = new StringBuffer();
+        msg.append("System Properties\n");
+        for (final Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+            msg.append("    ");
+            msg.append(entry.getKey());
+            msg.append("=");
+            msg.append(entry.getValue());
+            msg.append("\n");
+        }
+        final IStatus status = new Status(IStatus.INFO, Activator.PLUGIN_ID, msg.toString());
+        LOGGER.log(status);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.equinox.app.IApplication#stop()
+     */
+    @Override
+    public void stop() {
+        if (!PlatformUI.isWorkbenchRunning()) {
+            return;
+        }
+        final IWorkbench workbench = PlatformUI.getWorkbench();
+        final Display display = workbench.getDisplay();
+        display.syncExec(new Runnable() {
+            @Override
+            public void run() {
+                if (!display.isDisposed()) {
+                    workbench.close();
+                }
+            }
+        });
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,7 @@ If the link above does not work, which appear to be the case on some/many Linux 
 p2browser can be started using the following command on command line
 
     javaws  http://ifedorenko.github.com/p2-browser/javaws/com.ifedorenko.p2browser.jnlp
+
+p2browser uses the proxy configuration from the Java Control Panel. You should configure the 
+proxy server manually (option 'Use proxy server') because 'Use browser settings' doesn't work and 
+'Use automatic proxy configuration script' is not supported.


### PR DESCRIPTION
- when started via webstart, proxy configuriation is read from
  deployment.proxy.\* system properties
- when started as plain rcp (not via webstart), proxy configuration
  is read from http.proxy\* system properties
- native/system proxy configuration doesn't seem to work with webstart
